### PR TITLE
Skip packages if system is WSL

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -21,6 +21,10 @@
         update_cache: true
         cache_valid_time: 3600
 
+    - name: Set fact if system is WSL
+      ansible.builtin.set_fact:
+        is_wsl: "{{ 'Microsoft' in ansible_facts['virtualization_vendor'] }}"
+
   tasks:
     - name: Install tools
       ansible.builtin.include_tasks:
@@ -52,14 +56,17 @@
     - name: Install signal
       ansible.builtin.include_tasks:
         file: tasks/signal.yml
+      when: not is_wsl
 
     - name: Install spotify
       ansible.builtin.include_tasks:
         file: tasks/spotify.yml
+      when: not is_wsl
 
     - name: Install flatpak apps
       ansible.builtin.include_tasks:
         file: tasks/flathub.yml
+      when: not is_wsl
 
     - name: Configure Git
       ansible.builtin.include_tasks:

--- a/local.yml
+++ b/local.yml
@@ -23,7 +23,7 @@
 
     - name: Set fact if system is WSL
       ansible.builtin.set_fact:
-        is_wsl: "{{ 'Microsoft' in ansible_facts['virtualization_vendor'] }}"
+        is_wsl: "{{ 'WSL' in ansible_kernel }}"
 
   tasks:
     - name: Install tools

--- a/tasks/flathub.yml
+++ b/tasks/flathub.yml
@@ -6,6 +6,7 @@
     flatpakrepo_url: https://dl.flathub.org/repo/flathub.flatpakrepo
     method: user
   become: false
+  when: not is_wsl
 
 - name: Install packages from flathub
   community.general.flatpak:
@@ -14,3 +15,4 @@
       - com.notesnook.Notesnook
     method: user
   become: false
+  when: not is_wsl

--- a/tasks/signal.yml
+++ b/tasks/signal.yml
@@ -4,6 +4,7 @@
     cmd: "wget -O- https://updates.signal.org/desktop/apt/keys.asc | gpg --dearmor > /tmp/signal-desktop-keyring.gpg"
   args:
     creates: /tmp/signal-desktop-keyring.gpg
+  when: not is_wsl
 
 - name: Move GPG key to /usr/share/keyrings
   ansible.builtin.copy:
@@ -13,18 +14,22 @@
     owner: root
     group: root
     mode: '0644'
+  when: not is_wsl
 
 - name: Add Signal repository to apt sources
   ansible.builtin.apt_repository:
     repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] https://updates.signal.org/desktop/apt xenial main"
     state: present
     filename: signal-xenial
+  when: not is_wsl
 
 - name: Update APT package index
   ansible.builtin.apt:
     update_cache: true
+  when: not is_wsl
 
 - name: Install Signal Desktop
   ansible.builtin.apt:
     name: signal-desktop
     state: present
+  when: not is_wsl

--- a/tasks/spotify.yml
+++ b/tasks/spotify.yml
@@ -4,18 +4,22 @@
     curl -sS https://download.spotify.com/debian/pubkey_6224F9941A8AA6D1.gpg | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
   args:
     creates: /etc/apt/trusted.gpg.d/spotify.gpg
+  when: not is_wsl
 
 - name: Add Spotify repository
   ansible.builtin.lineinfile:
     path: /etc/apt/sources.list.d/spotify.list
     line: 'deb http://repository.spotify.com stable non-free'
     create: true
+  when: not is_wsl
 
 - name: Update APT package index
   ansible.builtin.apt:
     update_cache: true
+  when: not is_wsl
 
 - name: Install Spotify client
   ansible.builtin.apt:
     name: spotify-client
     state: present
+  when: not is_wsl


### PR DESCRIPTION
Fixes #13

Add conditions to skip desktop apps installation if the system is WSL.

* Add a pre_task in `local.yml` to set a fact `is_wsl` to true if the system is WSL.
* Add conditions in `local.yml` to skip Signal, Spotify, and Thunderbird tasks if `is_wsl` is true.
* Add conditions in `tasks/signal.yml` to skip tasks if `is_wsl` is true.
* Add conditions in `tasks/spotify.yml` to skip tasks if `is_wsl` is true.
* Add conditions in `tasks/flathub.yml` to skip tasks if `is_wsl` is true.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/maheshrijal/linux-dev-playbook/pull/14?shareId=a9c2445d-e5cf-401e-914c-a14d600f8b18).